### PR TITLE
Updated version of CSS file in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Load quill and style dependencies
 ```
 ```
 <link href="https://cdnjs.cloudflare.com/ajax/libs/quill/2.0.0-dev.3/quill.snow.min.css" rel="stylesheet">
-<link href="unpkg.com/quill-better-table@1.1.9/dist/quill-better-table.css" rel="stylesheet">
+<link href="https://unpkg.com/quill-better-table@1.2.4/dist/quill-better-table.css" rel="stylesheet">
 ```
 
 ES6


### PR DESCRIPTION
Hello, I simply change the version of the CSS in docs to the last version of the codepen example, which includes the two blue dots around selected cells.