### PR TITLE
Bugfix quill-better-table.js

### DIFF
--- a/dist/quill-better-table.js
+++ b/dist/quill-better-table.js
@@ -1694,7 +1694,7 @@ class table_TableContainer extends Container {
 
 
     delIndexes.forEach(delIndex => {
-      this.colGroup().children.at(delIndexes[0]).remove();
+      this.colGroup().children.at(delIndex).remove();
     });
     removedCells.forEach(cell => {
       cell.remove();


### PR DESCRIPTION
There was a problem at deleting columns.
It didn't delete the col from colgroup